### PR TITLE
Fix "Arcade" breadcrumb link

### DIFF
--- a/www/protected/views/layouts/main.php
+++ b/www/protected/views/layouts/main.php
@@ -36,7 +36,7 @@
 
   <?php if(isset($this->breadcrumbs)):?>
     <?php $this->widget('zii.widgets.CBreadcrumbs', array(
-      'homeLink' =>CHtml::link(Yii::t('app', 'Arcade'), "/site/arcade"),
+      'homeLink' => CHtml::link(Yii::t('app', 'Arcade'), Yii::app()->getBaseUrl() . "/index.php/site/arcade"),
       'links'=>$this->breadcrumbs,
     )); ?><!-- breadcrumbs -->
   <?php endif?>

--- a/www/themes/metadatagames/views/layouts/main.php
+++ b/www/themes/metadatagames/views/layouts/main.php
@@ -36,7 +36,7 @@
 
   <?php if(isset($this->breadcrumbs)):?>
     <?php $this->widget('zii.widgets.CBreadcrumbs', array(
-      'homeLink' =>CHtml::link(Yii::t('app', 'Arcade'), "/site/arcade"),
+      'homeLink' => CHtml::link(Yii::t('app', 'Arcade'), Yii::app()->getBaseUrl() . "/index.php/site/arcade"),
       'links'=>$this->breadcrumbs,
     )); ?><!-- breadcrumbs -->
   <?php endif?>


### PR DESCRIPTION
The "Arcade" breadcrumb link (at the upper left of most pages) previously
pointed to [hostname]/site/arcade, rather than the actual location
[hostname]/[baseURL]/index.php/site/arcade. In the case of the default build,
this base URL is "mg-game/www", but the fix allows for any base URL.

Note: the two different modified files are identical except for the line
endings - one uses Unix-style endings while the other uses Windows-style
endings. This will be addressed in a future commit.
