### PR TITLE
Apply Zentag querying to Zentag reskins, and update Zentag media limit to 300

### DIFF
--- a/www/protected/modules/games/components/BlBookTagGame.php
+++ b/www/protected/modules/games/components/BlBookTagGame.php
@@ -102,7 +102,7 @@ class BlBookTagGame extends MGGame implements MGGameInterface
             $used_medias = array();
 
             // get a one medias that is active for the game
-            $medias = $this->getMedias($collections, $game, $game_model);
+            $medias = $this->getMediasforZentag($collections, $game, $game_model);
 
 
             if ($medias && count($medias) > 0) {

--- a/www/protected/modules/games/components/BlPortraitTagGame.php
+++ b/www/protected/modules/games/components/BlPortraitTagGame.php
@@ -102,7 +102,7 @@ class BlPortraitTagGame extends MGGame implements MGGameInterface
             $used_medias = array();
 
             // get a one medias that is active for the game
-            $medias = $this->getMedias($collections, $game, $game_model);
+            $medias = $this->getMediasforZentag($collections, $game, $game_model);
 
 
             if ($medias && count($medias) > 0) {

--- a/www/protected/modules/games/components/BlShipsTagGame.php
+++ b/www/protected/modules/games/components/BlShipsTagGame.php
@@ -102,7 +102,7 @@ class BlShipsTagGame extends MGGame implements MGGameInterface
             $used_medias = array();
 
             // get a one medias that is active for the game
-            $medias = $this->getMedias($collections, $game, $game_model);
+            $medias = $this->getMediasforZentag($collections, $game, $game_model);
 
 
             if ($medias && count($medias) > 0) {

--- a/www/protected/modules/games/components/MGGame.php
+++ b/www/protected/modules/games/components/MGGame.php
@@ -201,7 +201,7 @@ class MGGame extends CComponent
     {
 
         $used_medias = $this->getUsedMedias($game, $game_model);
-        $num_media_threshold = 20;
+        $num_media_threshold = 300;
         //get media that have more tags than threshold from all active collection
         $selectedmedias = Yii::app()->db->createCommand()
 //            ->select('i.id,count(case when tu.tag_id is not null then 1 end) as counted')


### PR DESCRIPTION
This commit applies the new ZenTag querying to the various derivatives of
ZenTag (Ships Tag, Book Tag, and Portrait Tag). In addition, it updates the
media limit used by the query from 20 (used in testing) to 300.
