### PR TITLE
Analytics: Fix event logs being cut off in POST requests

### DIFF
--- a/www/js/mg.game.api.js
+++ b/www/js/mg.game.api.js
@@ -133,11 +133,11 @@ MG_GAME_API = function ($) {
           }, {
             type: 'post',
             data: {
-                eventlog : {
+                eventlog : JSON.stringify({
                     gameid: MG_GAME_API.settings.gid,
                     browser: navigator.userAgent,
                     events: MG_GAME_API.events,
-                }
+                }),
             }
         });
 

--- a/www/protected/modules/api/controllers/GamesController.php
+++ b/www/protected/modules/api/controllers/GamesController.php
@@ -481,7 +481,7 @@ class GamesController extends ApiController {
     if (!isset($_POST['eventlog'])) {
       return;
     }
-    $log = $_POST['eventlog'];
+    $log = CJSON::decode($_POST['eventlog']);
     $dir = "protected/analytics/".$gid."/";
 
     //Create unique filename


### PR DESCRIPTION
The PHP setting max_input_vars limits the number of variables in a POST
request (default value is 1000). As a result, longer event logs were being cut
off after 1000 attributes were stored (timestamps, actions, etc).

To solve the problem, the event log is now encoded as a JSON string (i.e: a
single variable) before sending it in a POST request to the server. The server
decodes it, parses the needed information, and saves it in a file.
