### PR TITLE
Fix GuessWhat to prevent multiword hint exploit

### DIFF
--- a/www/js/mg.game.api.js
+++ b/www/js/mg.game.api.js
@@ -246,6 +246,12 @@ MG_GAME_API = function ($) {
       }
     },
 
+    preventEvents : function (element, events) {
+      for (var i = 0; i < events.length; i++) {
+        element.bind(events[i], function (e) { e.preventDefault(); });
+      }
+    },
+
     /*
      * Standardized interface to call the GameAPI action. Allowing games to
      * implement additional API call back functions

--- a/www/protected/modules/games/assets/guesswhat/js/mg.game.guesswhat.js
+++ b/www/protected/modules/games/assets/guesswhat/js/mg.game.guesswhat.js
@@ -59,6 +59,9 @@ MG_GAME_GUESSWHAT = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_GUESSWHAT.wordField, ["paste", "cut", "copy"]);
+
             // submit on enter
             MG_GAME_GUESSWHAT.wordField.focus().keydown(function (event) {
                 if (event.keyCode == 13) {

--- a/www/protected/modules/games/assets/nextag/js/mg.game.nextag.js
+++ b/www/protected/modules/games/assets/nextag/js/mg.game.nextag.js
@@ -52,6 +52,9 @@ MG_GAME_NEXTAG = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_NEXTAG.wordField, ["paste", "cut", "copy"]);
+
             MG_GAME_NEXTAG.submitButton = $("#button-play").click(MG_GAME_NEXTAG.onsubmit);
             // TRY to get pass button to submit correct value.
             MG_GAME_NEXTAG.passButton = $("#button-pass").click(MG_GAME_NEXTAG.onpass);

--- a/www/protected/modules/games/assets/oneup/js/mg.game.oneup.main.js
+++ b/www/protected/modules/games/assets/oneup/js/mg.game.oneup.main.js
@@ -86,6 +86,9 @@ MG_GAME_ONEUP = function ($) {
 
             MG_GAME_ONEUP.wordField = $("#word");
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_ONEUP.wordField, ["paste", "cut", "copy"]);
+
             $('nav#menu-left').mmenu();
             $('nav#menu-right').mmenu({
                 position:'right',

--- a/www/protected/modules/games/assets/pyramid/js/mg.game.pyramid.js
+++ b/www/protected/modules/games/assets/pyramid/js/mg.game.pyramid.js
@@ -140,6 +140,9 @@ MG_GAME_PYRAMID = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_PYRAMID.wordField, ["paste", "cut", "copy"]);
+
             MG_GAME_PYRAMID.submitButton = $("#button-play").click(MG_GAME_PYRAMID.onsubmit);
             // Delete the default footer content.
             $("#footer").html("");

--- a/www/protected/modules/games/assets/stupidrobot/js/mg.game.stupidrobot.js
+++ b/www/protected/modules/games/assets/stupidrobot/js/mg.game.stupidrobot.js
@@ -464,6 +464,9 @@ MG_GAME_STUPIDROBOT = function ($) {
                 return event.which != 32;
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_STUPIDROBOT.wordField, ["paste", "cut", "copy"]);
+
             // set original level
             if (typeof(noTicker) == 'undefined')
                 MG_GAME_STUPIDROBOT.timerTick();

--- a/www/protected/modules/games/assets/zenpond/js/mg.game.zenpond.js
+++ b/www/protected/modules/games/assets/zenpond/js/mg.game.zenpond.js
@@ -40,6 +40,9 @@ MG_GAME_ZENPOND = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_ZENPOND.wordField, ["paste", "cut", "copy"]);
+
             MG_GAME_ZENPOND.submitButton = $("#button-play").click(MG_GAME_ZENPOND.onsubmit);
 
             // call the game API's init settings

--- a/www/protected/modules/games/assets/zentag/js/mg.game.zentag.js
+++ b/www/protected/modules/games/assets/zentag/js/mg.game.zentag.js
@@ -50,6 +50,9 @@ MG_GAME_ZENTAG = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_ZENTAG.wordField, ["paste", "cut", "copy"]);
+
             MG_GAME_ZENTAG.submitButton = $("#button-play").click(MG_GAME_ZENTAG.onsubmit);
             // TRY to get pass button to submit correct value.
             MG_GAME_ZENTAG.passButton = $("#button-pass").click(MG_GAME_ZENTAG.onpass);

--- a/www/protected/modules/games/assets/zentagplayoncemoveon/js/mg.game.zentagplayoncemoveon.js
+++ b/www/protected/modules/games/assets/zentagplayoncemoveon/js/mg.game.zentagplayoncemoveon.js
@@ -27,6 +27,9 @@ MG_GAME_ZENTAG_PLAYONCE = function ($) {
           return false;
         }
       });
+
+      //Prevent paste/cut/copy
+      MG_GAME_API.preventEvents(MG_GAME_ZENTAG_PLAYONCE.wordField, ["paste", "cut", "copy"]);
       
       MG_GAME_ZENTAG_PLAYONCE.submitButton = $("#button-play").click(MG_GAME_ZENTAG_PLAYONCE.onsubmit);
     // TRY to get pass button to submit correct value.


### PR DESCRIPTION
After the change to multiword parsing (commit 7453f3b9), it became much
easier for users to enter multiword hints. This has been fixed using
the same code that ZenTag uses, with some slight modifications. This
limits the characters that can be entered in the text area to just
letters (a-z, A-Z).
