### PR TITLE
Apply cut/copy/paste prevention to game-reskins

### DIFF
--- a/www/protected/modules/games/assets/blbooktag/js/mg.game.zentag.js
+++ b/www/protected/modules/games/assets/blbooktag/js/mg.game.zentag.js
@@ -50,6 +50,9 @@ MG_GAME_ZENTAG = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_ZENTAG.wordField, ["paste", "cut", "copy"]);
+
             // wikipedia tab
             $("#wikipedia .blue-tab").on("click", function() {
               $(this).closest(".tab-container").toggleClass("open");

--- a/www/protected/modules/games/assets/blportraittag/js/mg.game.zentag.js
+++ b/www/protected/modules/games/assets/blportraittag/js/mg.game.zentag.js
@@ -50,6 +50,9 @@ MG_GAME_ZENTAG = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_ZENTAG.wordField, ["paste", "cut", "copy"]);
+
             // wikipedia tab
             $("#wikipedia .blue-tab").on("click", function() {
               $(this).closest(".tab-container").toggleClass("open");

--- a/www/protected/modules/games/assets/blshipstag/js/mg.game.zentag.js
+++ b/www/protected/modules/games/assets/blshipstag/js/mg.game.zentag.js
@@ -50,6 +50,9 @@ MG_GAME_ZENTAG = function ($) {
                 }
             });
 
+            //Prevent paste/cut/copy
+            MG_GAME_API.preventEvents(MG_GAME_ZENTAG.wordField, ["paste", "cut", "copy"]);
+
             // wikipedia tab
             $("#wikipedia .blue-tab").on("click", function() {
               $(this).closest(".tab-container").toggleClass("open");


### PR DESCRIPTION
This commit adds calls to preventEvents() for each of the reskins of
ZenTag. More information can be found with commit 51bada95... which
applied the same changes to the other games.
